### PR TITLE
Support Semantic Scholar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/nlnjigejpgngahmoainkakaafabijeki)](https://chrome.google.com/webstore/detail/scholar-with-code/nlnjigejpgngahmoainkakaafabijeki)
 
-A simple chrome extension to present the number of available code implementions (via `Papers With Code`) for articles listed on `Google Scholar` and `arXiv`.
+A simple chrome extension to present the number of available code implementions (via `Papers With Code`) for articles listed on `Google Scholar`, `arXiv` and `Semantic Scholar`.
 
 <p align="center">
 <img src="docs/teaser_scholar.gif" width="800px"/>
@@ -13,6 +13,8 @@ A simple chrome extension to present the number of available code implementions 
 </p>
 
 ## Recent Updates
+**`2020.07.29`**: Added Semantic Scholar Support
+
 **`2020.07.15`**: Added arXiv Support
 
 **`2020.06.24`**: Chrome Extension release
@@ -40,3 +42,4 @@ As it is kind of annoying to go back and forth between the two, I've written a s
 - [x] Publish to Chrome Web Store
 - [x] Check how to remove permissions to all sites
 - [x] Support arXiv.org
+- [x] Support Semantic Scholar

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,12 @@
   "manifest_version": 2,
 
   "name": "Scholar with Code",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "icons":{
     "493":"docs/logo.png"
   },
   "description": "An extension to show code implementations from Papers with Code directly in Google Scholar.",
-  "permissions":["https://paperswithcode.com/*","https://scholar.google.com/*","https://scholar.google.co.il/*", "https://arxiv.org/*"],
+  "permissions":["https://paperswithcode.com/*","https://scholar.google.com/*","https://scholar.google.co.il/*", "https://arxiv.org/*", "https://www.semanticscholar.org/*"],
   "content_scripts": [{
     "js": ["src/content_scholar.js"],
     "matches": ["https://scholar.google.com/*","https://scholar.google.co.il/*"]
@@ -15,6 +15,10 @@
   {
     "js": ["src/content_arxiv.js"],
     "matches": ["https://arxiv.org/abs/*"]
+  },
+  {
+    "js": ["src/content_semantic_scholar.js"],
+    "matches": ["https://www.semanticscholar.org/*"]
   }],
   "background": {
    "scripts": ["src/background.js"],

--- a/src/content_semantic_scholar.js
+++ b/src/content_semantic_scholar.js
@@ -14,9 +14,11 @@ let observer = new MutationObserver((mutations) => {
 					var a = result.firstChild.cloneNode(true);
 					let xmlns = 'http://www.w3.org/2000/svg';
                     var svgElem = document.createElementNS(xmlns, "svg");
-                    svgElem.setAttributeNS(null, "viewBox", "0 0 24 24");
-                    svgElem.setAttributeNS(null, "width", 24);
-                    svgElem.setAttributeNS(null, "height", 24);
+					let iconSize = 18;
+					let viewSize = 432 / iconSize;
+                    svgElem.setAttributeNS(null, "viewBox", "0 0 " + viewSize + " " + viewSize);
+                    svgElem.setAttributeNS(null, "width", iconSize);
+                    svgElem.setAttributeNS(null, "height", iconSize);
                     var path1 = document.createElementNS(xmlns,"path");
                     path1.setAttributeNS(null, "d", "M0 0h24v24H0V0z");
                     path1.setAttributeNS(null, "fill", "none");

--- a/src/content_semantic_scholar.js
+++ b/src/content_semantic_scholar.js
@@ -1,3 +1,21 @@
+function makeIconElement() {
+    let xmlns = 'http://www.w3.org/2000/svg';
+    let svgElem = document.createElementNS(xmlns, "svg");
+    let iconSize = 18;
+    let viewSize = 432 / iconSize;
+    svgElem.setAttributeNS(null, "viewBox", "0 0 " + viewSize + " " + viewSize);
+    svgElem.setAttributeNS(null, "width", iconSize);
+    svgElem.setAttributeNS(null, "height", iconSize);
+    let path1 = document.createElementNS(xmlns, "path");
+    path1.setAttributeNS(null, "d", "M0 0h24v24H0V0z");
+    path1.setAttributeNS(null, "fill", "none");
+    let path2 = document.createElementNS(xmlns, "path");
+    path2.setAttributeNS(null, "d", "M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z");
+    svgElem.appendChild(path1);
+    svgElem.appendChild(path2);
+    return svgElem;
+}
+
 let observer = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
         if (!mutation.addedNodes) return
@@ -8,27 +26,16 @@ let observer = new MutationObserver((mutations) => {
             // Go over all regions and add code implementations
             for (let i = 0, l = results.length; i < l; i++) {
                 let title = results[i].childNodes[0].childNodes[0].textContent;
-                chrome.runtime.sendMessage({title: title, payload: i}, function(response) {
-                    let results = document.getElementsByClassName('paper-actions');				
-					let result = results[response.payload];
-					let a = result.firstChild.cloneNode(true);
-					let xmlns = 'http://www.w3.org/2000/svg';
-                    let svgElem = document.createElementNS(xmlns, "svg");
-					let iconSize = 18;
-					let viewSize = 432 / iconSize;
-                    svgElem.setAttributeNS(null, "viewBox", "0 0 " + viewSize + " " + viewSize);
-                    svgElem.setAttributeNS(null, "width", iconSize);
-                    svgElem.setAttributeNS(null, "height", iconSize);
-                    let path1 = document.createElementNS(xmlns,"path");
-                    path1.setAttributeNS(null, "d", "M0 0h24v24H0V0z");
-                    path1.setAttributeNS(null, "fill", "none");
-                    let path2 = document.createElementNS(xmlns,"path");
-                    path2.setAttributeNS(null, "d", "M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z");
-                    svgElem.appendChild(path1);
-                    svgElem.appendChild(path2);
-                    a.firstChild.replaceChild(svgElem, a.firstChild.firstChild);
-					a.firstChild.childNodes[1].innerText = response.txt;
+                chrome.runtime.sendMessage({
+                    title: title,
+                    payload: i
+                }, function(response) {
+                    let results = document.getElementsByClassName('paper-actions');
+                    let result = results[response.payload];
+                    let a = result.firstChild.cloneNode(true);
                     a.href = response.paper_link;
+                    a.firstChild.replaceChild(makeIconElement(), a.firstChild.firstChild);
+                    a.firstChild.childNodes[1].innerText = response.txt;
                     result.appendChild(a);
                 });
             }

--- a/src/content_semantic_scholar.js
+++ b/src/content_semantic_scholar.js
@@ -4,25 +4,25 @@ let observer = new MutationObserver((mutations) => {
         for (let i = 0; i < mutation.addedNodes.length; i++) {
             let node = mutation.addedNodes[i];
             if (!node.classList.contains('fresh-serp')) return
-            var results = document.getElementsByClassName('search-result-title');
+            let results = document.getElementsByClassName('search-result-title');
             // Go over all regions and add code implementations
             for (let i = 0, l = results.length; i < l; i++) {
-                var title = results[i].childNodes[0].childNodes[0].textContent;
+                let title = results[i].childNodes[0].childNodes[0].textContent;
                 chrome.runtime.sendMessage({title: title, payload: i}, function(response) {
-                    var results = document.getElementsByClassName('paper-actions');				
-					var result = results[response.payload];
-					var a = result.firstChild.cloneNode(true);
+                    let results = document.getElementsByClassName('paper-actions');				
+					let result = results[response.payload];
+					let a = result.firstChild.cloneNode(true);
 					let xmlns = 'http://www.w3.org/2000/svg';
-                    var svgElem = document.createElementNS(xmlns, "svg");
+                    let svgElem = document.createElementNS(xmlns, "svg");
 					let iconSize = 18;
 					let viewSize = 432 / iconSize;
                     svgElem.setAttributeNS(null, "viewBox", "0 0 " + viewSize + " " + viewSize);
                     svgElem.setAttributeNS(null, "width", iconSize);
                     svgElem.setAttributeNS(null, "height", iconSize);
-                    var path1 = document.createElementNS(xmlns,"path");
+                    let path1 = document.createElementNS(xmlns,"path");
                     path1.setAttributeNS(null, "d", "M0 0h24v24H0V0z");
                     path1.setAttributeNS(null, "fill", "none");
-                    var path2 = document.createElementNS(xmlns,"path");
+                    let path2 = document.createElementNS(xmlns,"path");
                     path2.setAttributeNS(null, "d", "M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z");
                     svgElem.appendChild(path1);
                     svgElem.appendChild(path2);

--- a/src/content_semantic_scholar.js
+++ b/src/content_semantic_scholar.js
@@ -1,0 +1,47 @@
+let observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+        if (!mutation.addedNodes) return
+        for (let i = 0; i < mutation.addedNodes.length; i++) {
+            let node = mutation.addedNodes[i];
+            if (!node.classList.contains('fresh-serp')) return
+            var results = document.getElementsByClassName('search-result-title');
+            // Go over all regions and add code implementations
+            for (let i = 0, l = results.length; i < l; i++) {
+                var title = results[i].childNodes[0].childNodes[0].textContent;
+                chrome.runtime.sendMessage({title: title, payload: i}, function(response) {
+                    var results = document.getElementsByClassName('paper-actions');				
+					var result = results[response.payload];
+					var a = result.firstChild.cloneNode(true);
+                    a.firstChild.childNodes[0].classList[1] = "icon-fa-code";
+					a.firstChild.childNodes[1].innerText = response.txt;
+                    a.href = response.paper_link;
+                    result.appendChild(a);
+                });
+            }
+        }
+    })
+})
+
+observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: false,
+    characterData: false
+})
+
+// stop watching using:
+// observer.disconnect()
+
+/*
+paper-actions example element:
+
+<a class="icon-button paper-link" data-selenium-selector="paper-link" data-heap-id="paper_link_target" data-heap-link-type="ieee" data-heap-direct-pdf-link="false" data-heap-unpaywall-link="false" data-heap-primary-link="true" data-heap-paper-id="f401f5067c35ae034cc6aedb9bbc876ebb5b570a" target="_blank" href="http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&amp;arnumber=9010003">
+   <span class="flex-row-centered">
+      <svg width="15" height="15" class="icon-svg icon-fa-link-out" data-selenium-selector="icon-fa-link-out">
+         <use xlink:href="#fa-link-out"></use>
+      </svg>
+      <span class="icon-button-text">View on IEEE</span>
+   </span>
+</a>
+
+*/

--- a/src/content_semantic_scholar.js
+++ b/src/content_semantic_scholar.js
@@ -12,7 +12,19 @@ let observer = new MutationObserver((mutations) => {
                     var results = document.getElementsByClassName('paper-actions');				
 					var result = results[response.payload];
 					var a = result.firstChild.cloneNode(true);
-                    a.firstChild.childNodes[0].classList[1] = "icon-fa-code";
+					let xmlns = 'http://www.w3.org/2000/svg';
+                    var svgElem = document.createElementNS(xmlns, "svg");
+                    svgElem.setAttributeNS(null, "viewBox", "0 0 24 24");
+                    svgElem.setAttributeNS(null, "width", 24);
+                    svgElem.setAttributeNS(null, "height", 24);
+                    var path1 = document.createElementNS(xmlns,"path");
+                    path1.setAttributeNS(null, "d", "M0 0h24v24H0V0z");
+                    path1.setAttributeNS(null, "fill", "none");
+                    var path2 = document.createElementNS(xmlns,"path");
+                    path2.setAttributeNS(null, "d", "M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z");
+                    svgElem.appendChild(path1);
+                    svgElem.appendChild(path2);
+                    a.firstChild.replaceChild(svgElem, a.firstChild.firstChild);
 					a.firstChild.childNodes[1].innerText = response.txt;
                     a.href = response.paper_link;
                     result.appendChild(a);
@@ -31,17 +43,3 @@ observer.observe(document.body, {
 
 // stop watching using:
 // observer.disconnect()
-
-/*
-paper-actions example element:
-
-<a class="icon-button paper-link" data-selenium-selector="paper-link" data-heap-id="paper_link_target" data-heap-link-type="ieee" data-heap-direct-pdf-link="false" data-heap-unpaywall-link="false" data-heap-primary-link="true" data-heap-paper-id="f401f5067c35ae034cc6aedb9bbc876ebb5b570a" target="_blank" href="http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&amp;arnumber=9010003">
-   <span class="flex-row-centered">
-      <svg width="15" height="15" class="icon-svg icon-fa-link-out" data-selenium-selector="icon-fa-link-out">
-         <use xlink:href="#fa-link-out"></use>
-      </svg>
-      <span class="icon-button-text">View on IEEE</span>
-   </span>
-</a>
-
-*/


### PR DESCRIPTION
Added the requested support. Some notes:
- Semantic Scholar takes its time when retrieving the results (there is a loading animation but the page is considered idle) so I needed a hook for delaying the script execution. I used a `MutationObserver` on `document.body` that waits until the results' nodes are added.
- The observer should `disconnect()` but I can't figure how to self-inform that the execution is done and it's no longer needed.
- The script should match only "https://www.semanticscholar.org/search*" but for some reason when redirected to the results' page from the home page the script isn't executed. A refresh solves it as it recognizes an explicit loading of a matched page but that's of course not good enough. So currently "https://www.semanticscholar.org/*" is used but it's inefficient because the observer is registered in the home page for no reason.
- The icon is embedded into the code as an SVG HTML element. I guess it's OK...
- Fixes #4 